### PR TITLE
Remove print statements

### DIFF
--- a/thetadata/client.py
+++ b/thetadata/client.py
@@ -742,8 +742,7 @@ class ThetaClient:
         t2 = time.time()
         df = parse_flexible_REST(response)
         t3 = time.time()
-        print(f'time for request.get: {t2-t1}')
-        print(f'time for parse_flexible_REST(): {t3-t2}')
+
         return df
 
     def get_opt_at_time(


### PR DESCRIPTION
They produce unnecessary noise. Generally, I would recommend using [`logger`](https://docs.python.org/3/library/logging.html) for all other print statements, so that the users would be able to adjust to their desired level.